### PR TITLE
fix: correctly load single entry without version

### DIFF
--- a/loader.c
+++ b/loader.c
@@ -264,6 +264,9 @@ static int16 cmp_entry(const struct entry *a, const struct entry *b)
 	if (a->uki_cluster != 0 && b->uki_cluster == 0) return 1;
 	if (b->uki_cluster != 0 && a->uki_cluster == 0) return -1;
 
+	if (a->linux[0] != 0 && b->linux[0] == 0) return 1;
+	if (b->linux[0] != 0 && a->linux[0] == 0) return -1;
+
 	cmp = cmp_alpha(a->sort_key, b->sort_key);
 	if (cmp != 0) return cmp;
 


### PR DESCRIPTION
Currently a boot partition with a single entry that does not specify a version fails to load.

Root cause is that without a version or sort key an entry does not sort above the uninitialized highest entry.
This fixes is by adjusting the sort function to make a non empty entry sort before empty ones.